### PR TITLE
:bug: Bugfix: save_dir TypeError

### DIFF
--- a/label_convert/coco_to_labelImg.py
+++ b/label_convert/coco_to_labelImg.py
@@ -29,7 +29,7 @@ class COCO2labelImg:
         self.verify_exists(self.train2017_dir)
         self.verify_exists(self.val2017_dir)
 
-        self.save_dir = save_dir
+        self.save_dir = Path(save_dir)
         if save_dir is None:
             self.save_dir = (
                 self.data_dir.parent / f"{self.data_dir.name}_labelImg_format"


### PR DESCRIPTION
Hi There. Fixed a bug.

__ERROR Point__
```
class COCO2labelImg:
    def __init__(...):
        ...
        self.save_dir = save_dir                 <----- Error Point
```

__ERROR Message:__
```
    self.save_train_dir = self.save_dir / "train"
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

__Bugfix__:
```
class COCO2labelImg:
    def __init__(...):
        ...
        self.save_dir = Path(save_dir)
```

Thank u.